### PR TITLE
Add workaround of an overlay priority bug

### DIFF
--- a/hl-sexp.el
+++ b/hl-sexp.el
@@ -71,7 +71,8 @@
   "Active the Hl-Sexp overlay on the current sexp in the current window.
 \(Unless it's a minibuffer window.)"
   (when hl-sexp-mode			; Could be made buffer-local.
-    (unless (window-minibuffer-p (selected-window)) ; silly in minibuffer
+    (unless (or (use-region-p) ; silly with active region
+                (window-minibuffer-p (selected-window))) ; silly in minibuffer
       (unless hl-sexp-overlay
 	(setq hl-sexp-overlay (make-overlay 1 1)) ; to be moved
 	(overlay-put hl-sexp-overlay 'face 'hl-sexp-face))


### PR DESCRIPTION
Disable sexp highlighting when selection region is active because of:
1) bug: highlight overlay hides selection overlay when selecting top-level forms
2) it's not very useful